### PR TITLE
Summary Detail Panel

### DIFF
--- a/app/components/header-toolbar/modal/template.hbs
+++ b/app/components/header-toolbar/modal/template.hbs
@@ -2,6 +2,7 @@
   targetAttachment='top'
   overlayClass='city-search-modal__overlay'
   containerClass='city-search-modal'
+  wrapperClass='city-search-wrapper'
   onClose=(action @close)
   animatable=true
   overlayPosition='sibling'

--- a/app/components/summary-detail/component.js
+++ b/app/components/summary-detail/component.js
@@ -1,0 +1,13 @@
+import Component from '@ember/component';
+import { action } from '@ember/object';
+import { classNames } from '@ember-decorators/component';
+
+@classNames('summary-detail')
+export default class SummaryDetail extends Component {
+  @action
+  onClose() {
+    if (typeof this.close === 'function') {
+      this.close();
+    }
+  }
+}

--- a/app/components/summary-detail/template.hbs
+++ b/app/components/summary-detail/template.hbs
@@ -1,0 +1,34 @@
+{{#modal-dialog
+  overlayClass='summary-detail-modal__overlay'
+  containerClass='summary-detail-modal'
+  wrapperClass='summary-detail-wrapper'
+  onClose=(action 'onClose')
+  animatable=true
+  overlayPosition='sibling'
+}}
+  <div class="summary-detail-modal__upper-right">
+    <button {{action 'onClose'}} class="city-search-modal__close">
+      {{svg-jar "close"}}
+    </button>
+  </div>
+
+  <div class="summary-detail-modal__body">
+    <h3 class="summary-detail-modal__head" data-test-summary-detail-title>
+      {{@summary.type.label}}
+    </h3>
+
+    <h4 class="summary-detail-modal__subhead">
+      <span>
+        En Savoir Plus
+      </span>
+    </h4>
+
+    <ul class="summary-detail-modal__list">
+      <li>
+        <a href="https://transformer.en-marche.fr" target="_blank" rel="noopener">
+          On l’a dit on le fait
+        </a>
+      </li>
+    </ul>
+  </div>
+{{/modal-dialog}}

--- a/app/components/summary-detail/template.hbs
+++ b/app/components/summary-detail/template.hbs
@@ -18,18 +18,63 @@
       {{@summary.type.label}}
     </h3>
 
+    <div class="summary-detail-modal__updated">
+      Mis à jour le {{@summary.type.updatedAt}}
+    </div>
+
     <h4 class="summary-detail-modal__subhead">
       <span>
-        En Savoir Plus
+        En savoir plus
       </span>
     </h4>
 
     <ul class="summary-detail-modal__list">
-      <li>
-        <a href="https://transformer.en-marche.fr" target="_blank" rel="noopener">
-          On l’a dit on le fait
-        </a>
-      </li>
+      {{#if @summary.type.oldolfLink}}
+        <li>
+          <a href={{@summary.type.oldolfLink}} target="_blank" rel="noopener">
+            On l’a dit on le fait
+          </a>
+        </li>
+      {{/if}}
+      {{#if @summary.type.eligibilityLink}}
+        <li>
+          <a href={{@summary.type.eligibilityLink}} target="_blank" rel="noopener">
+            Vérifier mon éligibilité
+          </a>
+        </li>
+      {{/if}}
     </ul>
+
+    {{#if @summary.type.citizenProjectsLink}}
+      <h4 class="summary-detail-modal__subhead">
+        <span>
+          Agir collectivement
+        </span>
+      </h4>
+
+      <ul class="summary-detail-modal__list">
+        <li>
+          <a href={{@summary.type.citizenProjectsLink}} target="_blank" rel="noopener">
+            Les projets citoyens
+          </a>
+        </li>
+      </ul>
+    {{/if}}
+
+    {{#if @summary.type.ideasWorkshopLink}}
+      <h4 class="summary-detail-modal__subhead">
+        <span>
+          Une idée pour faire encore mieux ?
+        </span>
+      </h4>
+
+      <ul class="summary-detail-modal__list">
+        <li>
+          <a href={{@summary.type.ideasWorkshopLink}} target="_blank" rel="noopener">
+            Faire une proposition sur l’Atelier des idées
+          </a>
+        </li>
+      </ul>
+    {{/if}}
   </div>
 {{/modal-dialog}}

--- a/app/components/summary-detail/template.hbs
+++ b/app/components/summary-detail/template.hbs
@@ -1,3 +1,4 @@
+{{set-body-class "no-scroll"}}
 {{#modal-dialog
   overlayClass='summary-detail-modal__overlay'
   containerClass='summary-detail-modal'

--- a/app/components/summary/component.js
+++ b/app/components/summary/component.js
@@ -9,18 +9,26 @@ export default class Summary extends Component {
 
   TEMPLATES = TEMPLATES
 
-  @computed('summary.type')
+  @computed('summary')
+  get type() {
+    if (this.summary && this.summary.type) {
+      return this.summary.type.code;
+    } else {
+      return null;
+    }
+  }
+
+  @computed('type')
   get metadata() {
-    let { type } = this.summary;
-    return this.TEMPLATES[type];
+    return this.TEMPLATES[this.type];
   }
 
   @computed('metadata')
   get label() {
-    return this.metadata ? this.metadata.label : this.summary.type;
+    return this.metadata ? this.metadata.label : this.type;
   }
 
-  @computed('metadata', 'summary.data')
+  @computed('metadata', 'summary.payload')
   get details() {
     if (!this.metadata) {
       return '';

--- a/app/components/summary/component.js
+++ b/app/components/summary/component.js
@@ -13,9 +13,9 @@ export default class Summary extends Component {
   get type() {
     if (this.summary && this.summary.type) {
       return this.summary.type.code;
-    } else {
-      return null;
     }
+
+    return null;
   }
 
   @computed('type')
@@ -23,9 +23,40 @@ export default class Summary extends Component {
     return this.TEMPLATES[this.type];
   }
 
-  @computed('metadata')
+  @computed('type')
   get label() {
-    return this.metadata ? this.metadata.label : this.type;
+    if (this.summary && this.summary.type) {
+      return this.summary.type.label;
+    }
+
+    return this.type;
+  }
+
+  @computed('type')
+  get sourceLink() {
+    if (this.summary && this.summary.type) {
+      return this.summary.type.sourceLink;
+    }
+
+    return null;
+  }
+
+  @computed('type')
+  get sourceLabel() {
+    if (this.summary && this.summary.type) {
+      return this.summary.type.sourceLabel;
+    }
+
+    return null;
+  }
+
+  @computed('type')
+  get updatedAt() {
+    if (this.summary && this.summary.type) {
+      return this.summary.type.updatedAt;
+    }
+
+    return null;
   }
 
   @computed('metadata', 'summary.payload')

--- a/app/components/summary/component.js
+++ b/app/components/summary/component.js
@@ -1,5 +1,5 @@
 import Component from '@ember/component';
-import { computed } from '@ember/object';
+import { computed, action } from '@ember/object';
 import { classNames } from '@ember-decorators/component';
 
 import TEMPLATES from './summary-templates';
@@ -45,5 +45,12 @@ export default class Summary extends Component {
     });
 
     return template;
+  }
+
+  @action
+  choose() {
+    if (typeof this.chooseSummary === 'function') {
+      this.chooseSummary();
+    }
   }
 }

--- a/app/components/summary/summary-templates.js
+++ b/app/components/summary/summary-templates.js
@@ -4,7 +4,6 @@ function formatNumber(num) {
 
 export default {
   suppression_taxe_habitation: {
-    label: "Suppression de la taxe d’habitation",
     template: function (payload) {
       return 'Pour <span>'+formatNumber(payload.nombre_foyers)+'</span> foyers dans votre commune, '+
           'la taxe d\'habitation a baissé de <span>'+formatNumber(payload.baisse_2018)+'</span> euros en 2018. '+
@@ -14,7 +13,6 @@ export default {
     }
   },
   couverture_fibre: {
-    label: "Couverture en fibre de tout le territoire",
     template: function (payload) {
       let str = [];
 
@@ -32,11 +30,9 @@ export default {
     }
   },
   maison_service_accueil_public: {
-    label: "Généralisation des maisons de service et d'accueil au public",
     template: 'Une Maison de service et d’accueil du public a ouvert dans votre commune. Pour plus d’information, cliquez <a href="https://www.maisondeservicesaupublic.fr" target="_blank">ici</a>.'
   },
   creation_entreprises: {
-    label: "Création nettes d'entreprises",
     template: function (payload) {
       let str = 'Depuis mai 2017, il y a <span>'+formatNumber(payload.entreprises)+'</span> entreprises de plus dans votre commune';
 
@@ -50,7 +46,6 @@ export default {
     }
   },
   baisse_nombre_chomeurs: {
-    label: "Baisse du nombre de chômeurs",
     template: function (payload) {
       let str = [];
 
@@ -66,19 +61,15 @@ export default {
     }
   },
   pass_culture: {
-    label: "Mise en place du Pass Culture",
     template: 'Dans votre commune, tous les jeunes de 18 ans peuvent expérimenter le PASS culture : c\'est une réserve de <span>500</span> euros pour s\'offrir des activités culturelles et artistiques. Découvrez le <a href="https://pass.culture.fr" target="_blank">ici</a>.'
   },
   emplois_francs: {
-    label: "Emplois francs",
     template: "Un quartier de votre commune est éligible au dispositif des emplois francs."
   },
   quartier_reconquete_republicaine: {
-    label: "Création d'un quartier de reconquête républicaine",
     template: "Un Quartier de Reconquête Républicaine a été déployé dans votre ville."
   },
   cheque_energie: {
-    label: "Chèque énergie",
     template: function (payload) {
       return 'Au niveau départemental, <span>'+formatNumber(payload.nombre_beneficiaires)+'</span> personnes bénéficient d’un chèque énergie, ' +
           'pour un montant moyen de <span>200</span> euros. ' +
@@ -86,14 +77,12 @@ export default {
     }
   },
   conversion_surface_agricole_bio: {
-    label: "Conversion de la surface agricole en bio",
     template: function (payload) {
       return 'Au niveau départemental, <span>'+formatNumber(payload.hectares_bio)+'</span> hectares sont désormais cultivés en agriculture biologique, '+
           'ou sont en cours de conversion. C’est <span>'+formatNumber(payload.progression)+'%</span> de plus qu’en 2017.';
     }
   },
   prime_conversion_automobile: {
-    label: "Prime à la conversion automobile",
     template: function (payload) {
       return 'Au niveau départemental, <span>' + formatNumber(payload.nombre_beneficiaires) + '</span> personnes ont pu bénéficier ' +
           'd’une prime à la conversion automobile d’un montant moyen de <span>' + formatNumber(payload.montant_moyen) + '</span> euros. ' +
@@ -101,7 +90,6 @@ export default {
     }
   },
   dedoublement_classes: {
-    label: "Dédoublement des classes de CP et CE1",
     template: function (payload) {
       if (1 === payload.total_cp_ce1) {
         return 'Dans votre commune, <span>1</span> classe de CP ou de CE1 a été dédoublée.';
@@ -111,7 +99,6 @@ export default {
     }
   },
   mission_bern: {
-    label: "Projet de rénovation du patrimoine financé par la mission Bern",
     template: function (payload) {
       let str = 'Un <a href="' + payload.lien + '" target="_blank">projet de rénovation</a> du patrimoine est soutenu par la Mission Bern';
 

--- a/app/components/summary/template.hbs
+++ b/app/components/summary/template.hbs
@@ -20,7 +20,7 @@
       <div class="summary-source-update">Mis à jour le This.update</div>
     </div>
 
-    <button class="summary-footer__button">
+    <button data-test-plus-button {{action 'choose'}} class="summary-footer__button">
       + Plus
     </button>
   </div>

--- a/app/components/summary/template.hbs
+++ b/app/components/summary/template.hbs
@@ -14,10 +14,12 @@
     <div class="summary-footer__source">
       <div class="summary-source-url">
         <span>Source</span>
-        <a href="#">This.source</a>
+        <a href={{{this.sourceLink}}} target="_blank" rel="noopener">
+          {{{this.sourceLabel}}}
+        </a>
         {{svg-jar "url"}}
       </div>
-      <div class="summary-source-update">Mis à jour le This.update</div>
+      <div class="summary-source-update">Mis à jour le {{{this.updatedAt}}}</div>
     </div>
 
     <button data-test-plus-button {{action 'choose'}} class="summary-footer__button">

--- a/app/styles/_util.scss
+++ b/app/styles/_util.scss
@@ -9,3 +9,7 @@
   width: 1px;
   white-space: nowrap;
 }
+
+.no-scroll {
+  overflow: hidden;
+}

--- a/app/styles/_vars.scss
+++ b/app/styles/_vars.scss
@@ -11,6 +11,7 @@ $pale-gray: #f6f9fc;
 $green-blue: #00aa7d;
 $blue-gray: #c4ccd9;
 $pale-blue: #EBF4FF;
+$pale-green: #d1f6dc;
 
 $altgray: #7B889B;
 $altgray-light: #D6DFE9;

--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -30,3 +30,4 @@ $breakpoints: (xlarge: 1440px, large: 667px, medium: 376px);
 @import "components/newsletter";
 @import "components/application-call";
 @import "components/footer";
+@import "components/summary-detail";

--- a/app/styles/components/_summary-detail.scss
+++ b/app/styles/components/_summary-detail.scss
@@ -1,0 +1,106 @@
+.summary-detail-modal {
+  border-radius: 0;
+  box-shadow: none;
+
+  padding: 20px;
+  height: 100vh;
+
+  width: 100%;
+
+  @include media('>=800px') {
+    padding: 110px 45px 60px;
+    width: 600px;
+  }
+
+  &.liquid-dialog.ember-modal-dialog {
+    position: fixed;
+    right: 0;
+  }
+
+  &__upper-right {
+    position: absolute;
+    top: 45px;
+    right: 45px;
+  }
+
+  &__head {
+    font-family: $font-roboto;
+    font-size: 24px;
+    font-weight: bold;
+    line-height: 1.25;
+    color: black;
+    margin-bottom: 15px;
+  }
+
+  &__subhead {
+    font-family: $font-roboto;
+    font-size: 16px;
+    font-weight: bold;
+    line-height: 1.5;
+    color: black;
+    text-transform: uppercase;
+    margin-bottom: 20px;
+
+    > span {
+      position: relative;
+
+      &:before {
+        content: '';
+        position: absolute;
+        z-index: -1;
+        background-color: $pale-green;
+        left: 0;
+        top: 8px;
+        height: 14px;
+        width: 100%;
+      }
+    }
+  }
+}
+
+.summary-detail-modal__body {
+  max-height: 100%;
+  overflow-y: auto;
+}
+
+.summary-detail-modal__overlay {
+  background-color: rgba($darkgray, 0.5);
+}
+
+.summary-detail-modal__close {
+  @include button;
+
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  opacity: 0.7;
+  transition: opacity 300ms;
+
+  &:hover {
+      opacity: 1;
+  }
+
+  .icon-close {
+    width: 30px;
+    height: 30px;
+  }
+}
+
+.summary-detail-modal__list {
+  padding: 0;
+  margin: 0 0 50px;
+  list-style: none;
+
+  &:last-child {
+    margin-bottom: 0;
+  }
+
+  li > a {
+    display: block;
+    color: $azure;
+    font-family: $font-roboto;
+    font-size: 16px;
+    font-weight: bold;
+    line-height: 1.5;
+  }
+}

--- a/app/styles/components/_summary-detail.scss
+++ b/app/styles/components/_summary-detail.scss
@@ -29,7 +29,11 @@
     font-weight: bold;
     line-height: 1.25;
     color: black;
-    margin-bottom: 15px;
+    margin-bottom: 5px;
+  }
+
+  &__updated {
+    font-size: 14px;
   }
 
   &__subhead {
@@ -40,6 +44,7 @@
     color: black;
     text-transform: uppercase;
     margin-bottom: 20px;
+    margin-top: 20px;
 
     > span {
       position: relative;
@@ -102,5 +107,6 @@
     font-size: 16px;
     font-weight: bold;
     line-height: 1.5;
+    margin-bottom: 15px;
   }
 }

--- a/app/templates/map/city.hbs
+++ b/app/templates/map/city.hbs
@@ -34,6 +34,7 @@
       {{#each model.measures as |summary|}}
         <Summary
           @summary={{summary}}
+          @chooseSummary={{action (mut summaryDetail) summary}}
           data-test-summary
         />
       {{/each}}
@@ -53,3 +54,11 @@
 <div class="wrapper__l" id="section-2">
   <ApplicationCall/>
 </div>
+
+{{#if summaryDetail}}
+  <SummaryDetail
+    @summary={{summaryDetail}}
+    @close={{action (mut summaryDetail) null}}
+    data-test-summary-detail
+  />
+{{/if}}

--- a/app/templates/map/city.hbs
+++ b/app/templates/map/city.hbs
@@ -42,6 +42,7 @@
   </div>
 </main>
 
+{{!--
 <div class="wrapper__l" id="section-1">
   <div class="el">
     <SocialsModule/>
@@ -50,6 +51,7 @@
     <Newsletter/>
   </div>
 </div>
+--}}
 
 <div class="wrapper__l" id="section-2">
   <ApplicationCall/>

--- a/app/transitions.js
+++ b/app/transitions.js
@@ -11,6 +11,16 @@ export default function() {
       use: [slideThenFade],
     }),
   );
+  this.transition(
+    this.hasClass('summary-detail-wrapper'),
+    this.use('explode', {
+      pick: '.ember-modal-overlay',
+      use: ['fade', {duration: 125}]
+    }, {
+      pick: '.ember-modal-dialog',
+      use: [slideInOut],
+    }),
+  );
 }
 
 function slideThenFade() {
@@ -23,5 +33,14 @@ function slideThenFade() {
       .then(() => animate(inner, {opacity: 1, duration: 250}));
   } else {
     return this.lookup('to-up').call(this, {duration: 200, easing: 'easeOut'});
+  }
+}
+
+function slideInOut() {
+  const OPS = {duration: 125, easing: 'easeInOut'};
+  if (this.newElement) {
+    return this.lookup('to-left').call(this, OPS);
+  } else {
+    return this.lookup('to-right').call(this, OPS);
   }
 }

--- a/app/transitions.js
+++ b/app/transitions.js
@@ -2,7 +2,7 @@ import { animate } from 'liquid-fire';
 
 export default function() {
   this.transition(
-    this.hasClass('liquid-dialog-container'),
+    this.hasClass('city-search-wrapper'),
     this.use('explode', {
       pick: '.ember-modal-overlay',
       use: ['fade', {duration: 250}]

--- a/circle.yml
+++ b/circle.yml
@@ -57,11 +57,6 @@ templates:
       tags:
         only: /^v[0-9]+\.[0-9]+\.[0-9]+/
 
-  filter_qa: &filter_qa
-    filters:
-      branches:
-        only: /[A-Za-z-_]+/[A-Za-z-_\d]+/
-
 jobs:
   build-static:
     <<: *defaults
@@ -113,7 +108,7 @@ workflows:
       - build-static:
           filters:
             branches:
-              ignore: /master|[A-Za-z-_]+/[A-Za-z-_\d]+/
+              ignore: master
       - test-static:
           requires:
             - build-static

--- a/mirage/factories/city-hit.js
+++ b/mirage/factories/city-hit.js
@@ -31,14 +31,18 @@ export default Factory.extend({
   ]),
   measures: () => ([
     {
-      type: "fiber_optic_coverage",
+      type: {
+        code: "fiber_optic_coverage"
+      },
       payload: {
         new_installations: 23,
         coverage: 8
       }
     },
     {
-      type: "total_new_houses",
+      type: {
+        code: "total_new_houses"
+      },
       payload: {
         houses_count: 2
       }

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "ember-qunit": "^4.4.1",
     "ember-resolver": "^5.0.1",
     "ember-responsive": "^3.0.1",
+    "ember-set-body-class": "^0.4.2",
     "ember-sinon": "^4.0.0",
     "ember-sinon-qunit": "^3.4.0",
     "ember-source": "~3.10.0",

--- a/tests/acceptance/map-test.js
+++ b/tests/acceptance/map-test.js
@@ -31,9 +31,15 @@ module('Acceptance | map', function(hooks) {
         coordinates: [ 48.6815276, 7.8407641 ]
       }],
       measures: [{
-        type: "creation_force_police_securite_quotidien",
+        type: {
+          code: "creation_force_police_securite_quotidien",
+          label: "foo",
+        },
       }, {
-        type: "total_nouvelles_maisons_service_au_public_departement",
+        type: {
+          code: "total_nouvelles_maisons_service_au_public_departement",
+          label: "bar",
+        },
       }],
     });
 
@@ -42,6 +48,11 @@ module('Acceptance | map', function(hooks) {
     assert.dom('[data-test-city-name]').hasText(NAME);
     assert.dom('[data-test-summary]').exists({count: 2});
     assert.dom('[data-test-filter] input').exists({count: 2});
+
+    await click('[data-test-plus-button]');
+
+    assert.dom('[data-test-summary-detail]').exists();
+    assert.dom('[data-test-summary-detail-title]').hasText('foo');
   });
 
   test('searching for a new city', async function(assert) {

--- a/tests/integration/components/summary-detail/component-test.js
+++ b/tests/integration/components/summary-detail/component-test.js
@@ -1,0 +1,21 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import hbs from 'htmlbars-inline-precompile';
+
+module('Integration | Component | summary-detail', function(hooks) {
+  setupRenderingTest(hooks);
+
+  test('it renders', async function(assert) {
+    this.set('SUMMARY', {
+      type: {
+        code: 'foo',
+        label: 'bar',
+      },
+    });
+
+    await render(hbs`<SummaryDetail @summary={{SUMMARY}} />`);
+
+    assert.dom('[data-test-summary-detail-title]').hasText('bar');
+  });
+});

--- a/tests/integration/components/summary/component-test.js
+++ b/tests/integration/components/summary/component-test.js
@@ -29,7 +29,6 @@ module('Integration | Component | summary', function(hooks) {
 
     await render(hbs`<Summary @TEMPLATES={{TEMPLATES}} @summary={{SUMMARY}}/>`);
 
-    assert.dom('[data-test-summary-label]').hasText(TEMPLATES.foo.label);
     assert.dom('[data-test-summary-dek]').hasText(EXPECTED);
   });
 
@@ -37,6 +36,7 @@ module('Integration | Component | summary', function(hooks) {
     const SUMMARY = {
       type: {
         code: 'foo',
+        label: 'bar',
       },
       payload: {
         number: 100,
@@ -47,7 +47,7 @@ module('Integration | Component | summary', function(hooks) {
 
     await render(hbs`<Summary @summary={{SUMMARY}}/>`);
 
-    assert.dom('[data-test-summary-label]').hasText('foo');
+    assert.dom('[data-test-summary-label]').hasText('bar');
   });
 
   test('it accepts a chooseSummary action', async function(assert) {

--- a/tests/integration/components/summary/component-test.js
+++ b/tests/integration/components/summary/component-test.js
@@ -14,7 +14,9 @@ module('Integration | Component | summary', function(hooks) {
       }
     };
     const SUMMARY = {
-      type: 'foo',
+      type: {
+        code: 'foo',
+      },
       payload: {
         foo: 100,
         bar: 500,
@@ -33,7 +35,9 @@ module('Integration | Component | summary', function(hooks) {
 
   test('it handles data without a corresponding template', async function(assert) {
     const SUMMARY = {
-      type: 'foo',
+      type: {
+        code: 'foo',
+      },
       payload: {
         number: 100,
       }

--- a/tests/integration/components/summary/component-test.js
+++ b/tests/integration/components/summary/component-test.js
@@ -1,6 +1,6 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { render } from '@ember/test-helpers';
+import { render, click } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 
 module('Integration | Component | summary', function(hooks) {
@@ -48,5 +48,15 @@ module('Integration | Component | summary', function(hooks) {
     await render(hbs`<Summary @summary={{SUMMARY}}/>`);
 
     assert.dom('[data-test-summary-label]').hasText('foo');
+  });
+
+  test('it accepts a chooseSummary action', async function(assert) {
+    assert.expect(1);
+
+    this.set('choose', () => assert.ok('called choose'));
+
+    await render(hbs`<Summary @chooseSummary={{choose}}/>`);
+
+    await click('[data-test-plus-button]');
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -5042,6 +5042,13 @@ ember-router-generator@^1.2.3:
   dependencies:
     recast "^0.11.3"
 
+ember-set-body-class@^0.4.2:
+  version "0.4.2"
+  resolved "https://registry.yarnpkg.com/ember-set-body-class/-/ember-set-body-class-0.4.2.tgz#93065767bb6a9f6754661d5bf52e473cdab69228"
+  integrity sha512-yAWDR2KWm7BYr5Iit1sOZwamfJI0t/2NiQKbNSiDNnIWnc9GdI6Muv22uYxRktFCvHgLHsp4+YD7YkcHjygJlg==
+  dependencies:
+    ember-cli-babel "^6.6.0"
+
 ember-sinon-qunit@^3.4.0:
   version "3.4.0"
   resolved "https://registry.yarnpkg.com/ember-sinon-qunit/-/ember-sinon-qunit-3.4.0.tgz#6c6ea96273572825e8789c7214e3fd3d9ef4c376"


### PR DESCRIPTION
I opened this PR against the css update PR so that the diff could be reviewed by other team members.

This PR:
- adds a new component (`<SummaryDetail/>`) to display additional details about a summary item (a `measure` from Aloglia)
- updates the `<Summary/>` component to work with the new data structure coming out of Algolia (cc: @Remg)
- adds a new transition for the `<SummaryDetail/>` reveal/hide
- corresponding tests

https://app.clubhouse.io/enmarche/story/9713/chezvous-create-a-toggable-pannel-for-extra-information-about-summaries
[9713]
https://app.zeplin.io/project/5ce41b08e30c3a1e685f78ab/screen/5d42a127959bdc2bdbe97cb0